### PR TITLE
feat: Add support to format all packages in cargo workspace

### DIFF
--- a/src/kraken/std/cargo/__init__.py
+++ b/src/kraken/std/cargo/__init__.py
@@ -132,10 +132,14 @@ def cargo_clippy(
     return task
 
 
-def cargo_fmt(*, project: Project | None = None) -> None:
+def cargo_fmt(
+    *,
+    all_packages: bool = False, 
+    project: Project | None = None
+) -> None:
     project = project or Project.current()
-    project.do("cargoFmt", CargoFmtTask, group="fmt")
-    project.do("cargoFmtCheck", CargoFmtTask, group="lint", check=True)
+    project.do("cargoFmt", CargoFmtTask, all_packages=all_packages, group="fmt")
+    project.do("cargoFmtCheck", CargoFmtTask, all_packages=all_packages, group="lint", check=True)
 
 
 def cargo_bump_version(

--- a/src/kraken/std/cargo/tasks/cargo_fmt_task.py
+++ b/src/kraken/std/cargo/tasks/cargo_fmt_task.py
@@ -7,11 +7,14 @@ from kraken.core import Property, Task, TaskStatus
 
 class CargoFmtTask(Task):
     check: Property[bool] = Property.default(False)
+    all: Property[bool] = Property.default(False)
 
     def execute(self) -> TaskStatus:
         command = ["cargo", "fmt"]
         if self.check.get():
             command += ["--check"]
+        if self.all_packages.get():
+            command += ["--all"]
         return TaskStatus.from_exit_code(command, sp.call(command, cwd=self.project.directory))
 
     def get_description(self) -> str | None:


### PR DESCRIPTION
* Added support to allow Kraken wrappers to build all packages inside of a cargo workspace by providing the `--all` option to `cargo fmt`
* Defaults to only building the package for the current project i.e. `--all` option is omitted from `cargo fmt`