### PR TITLE
fix: Cargo bump version preserves `workspace_members`  in manifest

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "3b3a2872-0721-4aad-bb66-85a92412f201"
 type = "feature"
 description = "Add `cargo_fmt(all_packages)` parameter"
 author = "callumPearce"
+
+[[entries]]
+id = "74349729-bbf6-43b4-bc55-26aea7ba79bc"
+type = "feature"
+description = "Fix preserve workspace_memebers in cargo manifest"
+author = "callumPearce"

--- a/src/kraken/std/cargo/manifest.py
+++ b/src/kraken/std/cargo/manifest.py
@@ -144,7 +144,10 @@ class Workspace:
         )
 
     def to_json(self) -> dict[str, Any]:
-        values = {"package": self.package.to_json() if self.package else None}
+        values = {
+            "package": self.package.to_json() if self.package else None,
+            "members": self.members if self.members else None,
+        }
         if self.unhandled is not None:
             values.update({k: v for k, v in self.unhandled.items() if v is not None})
         return {k: v for k, v in values.items() if v is not None}


### PR DESCRIPTION
* Calls to `cargo_bump_version` would remove the `workspace_members` entry in `Cargo.toml` for workspaces, this change ensures that `workspace_members` are instead preserved. 