### PR TITLE
Add check_lockfile task

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "c5cd1ad2-b903-4579-9157-6ec34cf00327"
+type = "feature"
+description = "Add `check_lockfile()` and `PythonBuildSystem.check_lockfile()` to check that the poetry.lock is compatible with pyproject.toml`"
+author = "@LozzaTray"

--- a/src/kraken/std/python/__init__.py
+++ b/src/kraken/std/python/__init__.py
@@ -1,6 +1,7 @@
 from .settings import PythonSettings, python_settings
 from .tasks.black_task import BlackTask, black
 from .tasks.build_task import BuildTask, build
+from .tasks.check_lockfile_task import check_lockfile_task
 from .tasks.flake8_task import Flake8Task, flake8
 from .tasks.install_task import InstallTask, install
 from .tasks.isort_task import IsortTask, isort
@@ -23,6 +24,7 @@ __all__ = [
     "BlackTask",
     "build",
     "BuildTask",
+    "check_lockfile_task",
     "flake8",
     "Flake8Task",
     "git_version_to_python_version",

--- a/src/kraken/std/python/buildsystem/__init__.py
+++ b/src/kraken/std/python/buildsystem/__init__.py
@@ -34,6 +34,11 @@ class PythonBuildSystem(abc.ABC):
     @abc.abstractmethod
     def update_pyproject(self, settings: PythonSettings, pyproject: Pyproject) -> None:
         """A chance to permanently update the Pyproject configuration."""
+    
+    @abc.abstractmethod
+    def check_lockfile(self, settings: PythonSettings, pyproject: Pyproject) -> TaskStatus:
+        """Check that the given lockfile is up to date. This is much faster to
+        execute than a full lockfile update."""
 
     @abc.abstractmethod
     def update_lockfile(self, settings: PythonSettings, pyproject: Pyproject) -> TaskStatus:

--- a/src/kraken/std/python/buildsystem/poetry.py
+++ b/src/kraken/std/python/buildsystem/poetry.py
@@ -42,6 +42,11 @@ class PoetryPythonBuildSystem(PythonBuildSystem):
             if index.is_package_source:
                 pyproject.upsert_poetry_source(index.alias, index.index_url, index.default, not index.default)
 
+    def check_lockfile(self, settings: PythonSettings, pyproject: Pyproject) -> TaskStatus:
+        command = ["poetry", "lock", "--check"]
+        sp.check_call(command, cwd=self.project_directory)
+        return TaskStatus.succeeded()
+
     def update_lockfile(self, settings: PythonSettings, pyproject: Pyproject) -> TaskStatus:
         command = ["poetry", "update"]
         sp.check_call(command, cwd=self.project_directory)

--- a/src/kraken/std/python/buildsystem/slap.py
+++ b/src/kraken/std/python/buildsystem/slap.py
@@ -41,6 +41,10 @@ class SlapPythonBuildSystem(PythonBuildSystem):
     def update_pyproject(self, settings: PythonSettings, pyproject: Pyproject) -> None:
         if "poetry" in pyproject.get("tool", {}):
             PoetryPythonBuildSystem(self.project_directory).update_pyproject(settings, pyproject)
+    
+    def check_lockfile(self, settings: PythonSettings, pyproject: Pyproject) -> None:
+        if "poetry" in pyproject.get("tool", {}):
+            PoetryPythonBuildSystem(self.project_directory).check_lockfile(settings, pyproject)
 
     def update_lockfile(self, settings: PythonSettings, pyproject: Pyproject) -> TaskStatus:
         return TaskStatus.skipped("not supported")

--- a/src/kraken/std/python/tasks/check_lockfile_task.py
+++ b/src/kraken/std/python/tasks/check_lockfile_task.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from kraken.core.api import Project, Property, Task, TaskStatus
+from nr.stream import Supplier
+
+from ..buildsystem import PythonBuildSystem
+from ..pyproject import Pyproject
+from ..settings import PythonSettings, python_settings
+
+
+class CheckLockfileTask(Task):
+    settings: Property[PythonSettings]
+    build_system: Property[Optional[PythonBuildSystem]]
+    pyproject_toml: Property[Path]
+
+    def get_description(self) -> str | None:
+        build_system = self.build_system.get()
+        return (
+            f"Check your lock file is up to date in your Python project. [build system: "
+            f"{build_system.name if build_system else None}]"
+        )
+
+    def execute(self) -> TaskStatus:
+        build_system = self.build_system.get()
+        if not build_system:
+            return TaskStatus.failed("no build system configured")
+        settings = self.settings.get()
+        pyproject = Pyproject.read(self.pyproject_toml.get())
+        return build_system.check_lockfile(settings, pyproject)
+
+
+def check_lockfile_task(
+    *,
+    name: str = "python.update",
+    group: str | None = "update",
+    as_version: str | None = None,
+    project: Project | None = None,
+) -> CheckLockfileTask:
+    """Creates an update task for the given project.
+
+    The update task relies on the build system configured in the Python project settings."""
+
+    project = project or Project.current()
+    task = project.do(
+        name,
+        CheckLockfileTask,
+        group=group,
+        settings=python_settings(project),
+        build_system=Supplier.of_callable(lambda: python_settings(project).build_system),
+        pyproject_toml=project.directory / "pyproject.toml",
+    )
+    return task


### PR DESCRIPTION
Add support for a `check_lockfile` task in python that can be run in CI to verify that `poetry.lock` is compatible with `pyproject.toml` as a cheap check to prevent merging a broken lockfile.